### PR TITLE
(#63) Add support for remote flag & PouchDB 6.2.

### DIFF
--- a/lib/writable-stream.js
+++ b/lib/writable-stream.js
@@ -26,6 +26,8 @@ function WritableStreamPouch(opts, callback) {
     api.ndj.pipe(stream);
   };
 
+  api._remote = true;
+
   /* istanbul ignore next */
   api.type = function () {
     return 'writableStream';


### PR DESCRIPTION
I've added the support for PouchDB 6.2 by adding the _remote property. It fixes #63. 
However, the test do not run successfully (and did not before my modifications) because a new PouchDB with the same name is created in the dump function. When closed, this cause the destruct listeners to be removed, and since the destruct listeners are "global" and by name, they are removed for both databases: the source and the copy for streaming.
I've had the test run successfully by prefixing the copy with "WS$", but I find this hacky so this is not part of this commit. Please advise on this one.