### PR TITLE
Replication with selector for CouchDB 2.x.x

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ var ALLOWED_PARAMS = [
   'filter',
   'doc_ids',
   'query_params',
+  'selector',
   'since',
   'view'
 ];


### PR DESCRIPTION
Allow replication with selector for CouchDB 2.x.x. See https://pouchdb.com/api.html#replication