### PR TITLE
Add the `live` option to allowed params

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,8 @@ var ALLOWED_PARAMS = [
   'doc_ids',
   'query_params',
   'since',
-  'view'
+  'view',
+  'live'
 ];
 
 exports.adapters = {};


### PR DESCRIPTION
Thanks for the module -- it's proven really useful in my application! I was wondering: is there any reason that `live` is excluded from `ALLOWED_PARAMS`? In my testing, `db.sync` behavior can be replicated nicely by adding this option and calling `dump`/`load` from a set of input/output streams once, when the DB is first created.

Any complexities I'm overlooking here that could lead to future errors? If not, then this might be a useful change for  others. Thanks again!